### PR TITLE
Fix: 스크립트 태그 순서 변경 - 카카오 로그인 에러 픽스

### DIFF
--- a/pages/career/index.html
+++ b/pages/career/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="./style.css" />
-    <script type="module" src="/components/component.js"></script>
     <title>디지털 하나로 채용 관련</title>
   </head>
 
@@ -99,9 +98,9 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
   </body>
 </html>

--- a/pages/community/board/detail/index.html
+++ b/pages/community/board/detail/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -80,9 +78,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/board/index.html
+++ b/pages/community/board/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -64,10 +62,10 @@
     </main>
 
     <footer class="inner footer-component" id="footer"></footer>
-
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/board/posting/index.html
+++ b/pages/community/board/posting/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -72,9 +70,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/notice/detail/index.html
+++ b/pages/community/notice/detail/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -80,9 +78,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/notice/index.html
+++ b/pages/community/notice/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -65,9 +63,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/notice/posting/index.html
+++ b/pages/community/notice/posting/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -67,9 +65,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/qna/detail/index.html
+++ b/pages/community/qna/detail/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -80,9 +78,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/qna/index.html
+++ b/pages/community/qna/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -65,9 +63,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/community/qna/posting/index.html
+++ b/pages/community/qna/posting/index.html
@@ -8,8 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="index.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -72,9 +70,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/curriculum/calendar/index.html
+++ b/pages/curriculum/calendar/index.html
@@ -8,14 +8,12 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer src="./index.js"></script>
     <title>교육 과정</title>
     <style></style>
   </head>
   <body>
     <header class="inner header-component" id="header"></header>
-    
+
     <main class="inner">
       <div class="container">
         <div class="aside">
@@ -35,14 +33,16 @@
         </div>
         <div class="page-container">
           <header>
-            <div class="calendar-head"><span class="calendar-text">교육 과정</span></div>
+            <div class="calendar-head">
+              <span class="calendar-text">교육 과정</span>
+            </div>
           </header>
           <div class="calendar-container">
             <div class="calendar1">
               <div class="calendar-month">
-                <button class="previous" onclick="prevCalendar()"><</button>
+                <button class="previous" onclick="prevCalendar()">&lt;</button>
                 <div id="month">mm월</div>
-                <button class="next" onclick="nextCalendar()">></button>
+                <button class="next" onclick="nextCalendar()">&gt;</button>
               </div>
               <div class="calendar-day">
                 <table id="calendar">
@@ -79,12 +79,13 @@
           </div>
         </div>
       </div>
-    </div>
     </main>
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/curriculum/lecturer/index.html
+++ b/pages/curriculum/lecturer/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
     <title>강사 소개</title>
     <style></style>
   </head>
@@ -82,9 +81,10 @@
 
     <footer class="inner footer-component" id="footer"></footer>
 
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>

--- a/pages/introduction/index.html
+++ b/pages/introduction/index.html
@@ -9,10 +9,6 @@
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer type="module" src="./index.js"></script>
-    <script defer type="module" src="./utils.js"></script>
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <title>디지털 하나로 소개 페이지</title>
     <style></style>
   </head>
@@ -437,11 +433,13 @@
     </main>
 
     <footer class="inner footer-component" id="footer"></footer>
-
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
+    <script defer type="module" src="utils.js"></script>
+    <script async src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script>
       AOS.init();
     </script>

--- a/pages/main/index.html
+++ b/pages/main/index.html
@@ -9,17 +9,7 @@
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="./chatbot/chatbot.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
-    <script defer src="slackApi.js"></script>
-    <script defer src="board.js" type="module"></script>
-    <script defer type="module" src="./chatbot/Store.js"></script>
-    <script defer type="module" src="./chatbot/chatbotData.js"></script>
-    <script defer type="module" src="./chatbot/chatbotFunctions.js"></script>
-    <script defer type="module" src="./chatbot/chatbot.js"></script>
     <title>디지털 하나로 메인 페이지</title>
-    <script async src="slackApi.js"></script>
-    <script src="board.js" type="module"></script>
-
   </head>
   <body>
     <header class="inner header-component" id="header"></header>
@@ -34,7 +24,10 @@
                   <div class="extraText">디지털 하나로</div>
                   <div>#금융 #개발 #풀스택개발자</div>
                 </div>
-                <img class="mainCarouselImage" src="../../public/images/캐러셀1.png"></img>
+                <img
+                  class="mainCarouselImage"
+                  src="../../public/images/캐러셀1.png"
+                />
               </div>
 
               <div class="carousel-item">
@@ -43,7 +36,10 @@
                   <div class="extraText">디지털 하나로</div>
                   <div>#청춘 #미래 #행복</div>
                 </div>
-                <img class="mainCarouselImage" src="../../public/images/캐러셀2.png"></img>
+                <img
+                  class="mainCarouselImage"
+                  src="../../public/images/캐러셀2.png"
+                />
                 <!-- 두 번째 슬라이드 내용 -->
               </div>
 
@@ -51,9 +47,12 @@
                 <div class="mainCarouselText">
                   <div>하나의 팀이 되는</div>
                   <div class="extraText">디지털 하나로</div>
-                  <div>#원팀 #좋은동료 </div>
+                  <div>#원팀 #좋은동료</div>
                 </div>
-                <img class="mainCarouselImage" src="../../public/images/캐러셀3.png"></img>
+                <img
+                  class="mainCarouselImage"
+                  src="../../public/images/캐러셀3.png"
+                />
                 <!-- 세 번째 슬라이드 내용 -->
               </div>
 
@@ -63,7 +62,10 @@
                   <div class="extraText">디지털 하나로~</div>
                   <div>#열공 #화이팅 #워라밸</div>
                 </div>
-                <img class="mainCarouselImage" src="../../public/images/캐러셀4.png"></img>
+                <img
+                  class="mainCarouselImage"
+                  src="../../public/images/캐러셀4.png"
+                />
                 <!-- 네 번째 슬라이드 내용 -->
               </div>
               <!-- 추가 슬라이드 아이템들 -->
@@ -84,9 +86,7 @@
         <div class="middle-right">
           <div class="todayTable">
             <div class="todayTableTitle">오늘 시간표</div>
-            <div class="todayTableContent">
-
-            </div>
+            <div class="todayTableContent"></div>
           </div>
           <a href="./lunch/index.html">
             <div class="whatShouldIEatButton" onclick="index.html">
@@ -130,7 +130,6 @@
             <a href="../community/notice" class="mainBottomNoticeLearnButton"
               >+더보기</a
             >
-          
           </div>
           <div class="mainBottomNoticeBottom">
             <div class="">
@@ -158,7 +157,9 @@
         <div class="mainBottomBoard">
           <div class="mainBottomBoardTop">
             <div class="mainBottomBoardText">자유게시판</div>
-            <a href="../community/board" class="mainBottomBoardLearnButton">+더보기</a>
+            <a href="../community/board" class="mainBottomBoardLearnButton"
+              >+더보기</a
+            >
           </div>
           <div class="mainBottomBoardBottom"></div>
         </div>
@@ -166,7 +167,13 @@
     </main>
 
     <section class="chatbotWrapper">
-      <div class="chatbotButton"><img class='chatbotButtonImage' src="https://haitalk.kebhana.com/aicc/soe/service/storage/49e50558-09e8-47f2-b567-93b2a41099fc" alt=""></div>
+      <div class="chatbotButton">
+        <img
+          class="chatbotButtonImage"
+          src="https://haitalk.kebhana.com/aicc/soe/service/storage/49e50558-09e8-47f2-b567-93b2a41099fc"
+          alt=""
+        />
+      </div>
     </section>
 
     <div class="modalBackground hidden"></div>
@@ -181,11 +188,18 @@
     </section>
 
     <footer class="inner footer-component" id="footer"></footer>
-    <script defer src="today.js"> </script>
-    <script defer src="index.js"></script>
+
     <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script defer type="modules" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>
-
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer src="slackApi.js"></script>
+    <script defer src="board.js" type="module"></script>
+    <script defer type="module" src="./chatbot/Store.js"></script>
+    <script defer type="module" src="./chatbot/chatbotData.js"></script>
+    <script defer type="module" src="./chatbot/chatbotFunctions.js"></script>
+    <script defer type="module" src="./chatbot/chatbot.js"></script>
+    <script defer src="today.js"></script>
+    <script defer src="index.js"></script>
   </body>
 </html>

--- a/pages/main/lunch/index.html
+++ b/pages/main/lunch/index.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="/components/footer/footer.css" />
     <link rel="stylesheet" href="style.css" />
-    <script defer type="module" src="/components/component.js"></script>
     <title>Document</title>
   </head>
   <body>
@@ -20,10 +19,13 @@
         <div class="rullet-top-subtitle">디지털 하나로 주변 맛집 찾기</div>
       </div>
       <div class="roullet-component">
-       
-        <div class = "roullet-canvas">
+        <div class="roullet-canvas">
           <canvas width="300" height="300"></canvas>
-          <img src="../../../public/images/arrow.svg" width="120" class="rul-cursor"></img>
+          <img
+            src="../../../public/images/arrow.svg"
+            width="120"
+            class="rul-cursor"
+          />
         </div>
         <div>
           <button class="rullet-button" onclick="rotate()">
@@ -34,16 +36,14 @@
     </main>
 
     <footer class="inner footer-component" id="footer"></footer>
-
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
-
-    <script type="modules" src="/scripts/apikey.js"></script>
-    <script defer type="module" src="/scripts/kakaoLogin.js"></script>
-
     <script
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0ac5b958752d7cb070f6e4eb29c305bc&libraries=services"
     ></script>
-    <script src="index.js"></script>
+    <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script defer type="modules" src="/scripts/apikey.js"></script>
+    <script defer type="module" src="/scripts/kakaoLogin.js"></script>
+    <script defer type="module" src="/components/component.js"></script>
+    <script defer type="module" src="index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### 코드 작성 이유
스크립트 태그 순서 변경 후 메인페이지에서 헤더생성이 안되는 문제 해결

<br>

### 상세 사항
레이아웃 시프팅 해결 위해 스크립트 태그 순서 변경 후 메인페이지에서 헤더생성이 안되는 문제 해결
> `component.js`에 `kakaologin()` 함수 실행이 있어 `kakaologin.js`를 먼저 실행하도록 변경
<br>

### 참고 사항
- 상단 meta태그가 너무 많아 스크립트를 body 하단으로 이동
- 메인페이지 이미지 태그 수정 (`<img></img>` -> `<img />`)
- 교육페이지 불필요한 `</div>` 삭제
- 교육페이지의 `<`, `>`를 `&lt;`, `&gt;`으로 수정
<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
