### PR TITLE
Fix: 달력 이동 에러 픽스

### DIFF
--- a/pages/curriculum/calendar/index.html
+++ b/pages/curriculum/calendar/index.html
@@ -40,9 +40,9 @@
           <div class="calendar-container">
             <div class="calendar1">
               <div class="calendar-month">
-                <button class="previous" onclick="prevCalendar()">&lt;</button>
-                <div id="month">mm월</div>
-                <button class="next" onclick="nextCalendar()">&gt;</button>
+                <button class="previous">&lt;</button>
+                <div id="month"> 5월</div>
+                <button class="next">&gt;</button>
               </div>
               <div class="calendar-day">
                 <table id="calendar">

--- a/pages/curriculum/calendar/index.js
+++ b/pages/curriculum/calendar/index.js
@@ -152,7 +152,7 @@ const renderCalendarTemplate = () => {
 
   // 나머지 요일 그리기
   if (cnt % 7 != 0) {
-    for (i = 0; i < 7 - (cnt % 7); i++) {
+    for (let i = 0; i < 7 - (cnt % 7); i++) {
       cell = row.insertCell();
     }
   }
@@ -161,6 +161,9 @@ const renderCalendarTemplate = () => {
 const renderCalendarTitle = $title => {
   $title.innerHTML = `
   ${(today.getMonth() + 1).toString().padStart(2, ' ')}월`;
+
+  document.querySelector('.previous').addEventListener('click', prevCalendar);
+  document.querySelector('.next').addEventListener('click', nextCalendar);
 };
 
 const renderCalendarContents = calendarData => {


### PR DESCRIPTION
### 코드 작성 이유
1. 변수 초기화가 없어 데이터 순회 에러 발생
2. script 실행 시점 변경으로 nextCalendar, prevCalendar 핸들러가 붙지 않음
<br>

### 상세 사항

> 1. let 키워드 추가
> 2. html이 아닌 javascript 코드상에서 onclick 핸들러를 붙여주었음

<br>

### 참고 사항
- mm월 이었던 기본값을 5월로 변경
<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
