### PR TITLE
Fix: 교육페이지 주요활동 렌더 시 null 에러 수정

### DIFF
--- a/pages/curriculum/calendar/index.html
+++ b/pages/curriculum/calendar/index.html
@@ -53,7 +53,18 @@
             </div>
             <div class="calendar2">
               <div class="calendar2-row1">
-                <div id="monthly-schedule"></div>
+                <div id="monthly-schedule">
+                  <p id="summaryMonth">mm월 주요 활동</p>
+                  <ul></ul>
+                </div>
+                <div id="special-time">
+                  <p id="specialCommute">시간 특이사항</p>
+                  <ul></ul>
+                </div>
+                <div id="special-lecture">
+                  <p id="specialLecture">특강</p>
+                  <ul></ul>
+                </div>
               </div>
             </div>
           </div>

--- a/pages/curriculum/calendar/index.js
+++ b/pages/curriculum/calendar/index.js
@@ -7,21 +7,9 @@ function buildCalendar(calendarData, holidayData, timeData, specialData) {
     console.error('Error: Cannot find calendar table or month element.');
     return;
   }
-  const cal = document.querySelector('#calendar');
-  cal.innerHTML = `
-  <tr class="day-week">
-                    <th class="day-week">일</th>
-                    <th class="day-week">월</th>
-                    <th class="day-week">화</th>
-                    <th class="day-week">수</th>
-                    <th class="day-week">목</th>
-                    <th class="day-week">금</th>
-                    <th class="day-week">토</th>
-                  </tr> 
-  `;
+
   renderCalendarTitle();
   renderCalendarTemplate();
-
   renderCalendarContents(calendarData);
 
   renderSpecialSchedules(specialData, monthKey, 'special-lecture');
@@ -104,7 +92,18 @@ const nextCalendar = () => {
 };
 
 const renderCalendarTemplate = () => {
-  let calendarTable = document.getElementById('calendar');
+  const calendarTable = document.querySelector('#calendar');
+  calendarTable.innerHTML = `
+    <tr class="day-week">
+      <th class="day-week">일</th>
+      <th class="day-week">월</th>
+      <th class="day-week">화</th>
+      <th class="day-week">수</th>
+      <th class="day-week">목</th>
+      <th class="day-week">금</th>
+      <th class="day-week">토</th>
+    </tr> 
+  `;
 
   let firstDate = new Date(today.getFullYear(), today.getMonth(), 1);
   let lastDate = new Date(today.getFullYear(), today.getMonth() + 1, 0);
@@ -171,9 +170,9 @@ const renderCalendarTemplate = () => {
 const renderCalendarTitle = () => {
   const calendarMonth = document.querySelector('.calendar-month');
   calendarMonth.innerHTML = `
-  <button class="previous" onclick="prevCalendar()"><</button>
-                <div id="month"></div>
-                <button class="next" onclick="nextCalendar()">></button>
+    <button class="previous"><</button>
+      <div id="month"></div>
+    <button class="next">></button>
   `;
   let $title = document.getElementById('month');
 


### PR DESCRIPTION
### 코드 작성 이유
HTML 구조 변경으로 캘린더 주요활동 렌더 시 null 에러 발생
<br>

### 상세 사항
- HTML 구조 복구
- 불필요한 onclick제거, 함수 추상화 레벨 정리
<br>

### 참고 사항

<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
