### PR TITLE
Fix: 31일에서 다음달로 넘어갈 경우 2달이 넘어가는 에러 픽스

### DIFF
--- a/pages/curriculum/calendar/index.js
+++ b/pages/curriculum/calendar/index.js
@@ -65,11 +65,7 @@ const prevCalendar = () => {
   const currentMonth = today.getMonth();
 
   if (currentYear === targetYear && currentMonth > targetMonth) {
-    today = new Date(
-      today.getFullYear(),
-      today.getMonth() - 1,
-      today.getDate()
-    );
+    today = new Date(today.getFullYear(), today.getMonth() - 1, 1);
     fetchOrBuildCalendar();
   }
 };
@@ -82,11 +78,7 @@ const nextCalendar = () => {
   const currentMonth = today.getMonth();
 
   if (currentYear == targetYear && currentMonth < targetMonth) {
-    today = new Date(
-      today.getFullYear(),
-      today.getMonth() + 1,
-      today.getDate()
-    );
+    today = new Date(today.getFullYear(), today.getMonth() + 1, 1);
     fetchOrBuildCalendar();
   }
 };


### PR DESCRIPTION
### 코드 작성 이유
5월 31일 금일 nextCalendar 함수 호출 시 6월31일 -> 7월 1일로 변경되는 에러 픽스
<br>

### 상세 사항
nextCalendar, prevCalendar 에서 date를 1일로 고정
<br>

### 참고 사항

<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
