### PR TITLE
FIx: 사파리 스크립트 에러 픽스

### DIFF
--- a/pages/career/index.html
+++ b/pages/career/index.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="/components/header/header.css" />
     <link rel="stylesheet" href="./style.css" />
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet" />
-    <script async defer src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
     <script defer src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <script defer type="module" src="/scripts/apikey.js"></script>
     <script defer type="module" src="/scripts/kakaoLogin.js"></script>


### PR DESCRIPTION
### 코드 작성 이유
사파리 스크립트 에러 발생으로 지원페이지 로딩 에러 발생
<br>

### 상세 사항

<br>

### 참고 사항
- safari에서 `<script>` 태그에 async defer 넣을 시 AOS 에러가 발생함... 원인 파악이 안되는 중
<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
