### PR TITLE
Chore: 헤더로고 및 이모지 이미지 src 웹으로 변경

### DIFF
--- a/pages/main/chatbot/chatbotData.js
+++ b/pages/main/chatbot/chatbotData.js
@@ -236,19 +236,45 @@ export const GEAR_ICON_SVG_TAG = `
   </svg>`;
 
 const getEmoji = emojiFileName => {
-  return `<img src="/public/emojis/${emojiFileName}" height="18px" width="18px"/>`;
+  return `<img src="/public/emojis/${emojiFileName}" height="18px" width="18px" alt="faqButtonEmoji" />`;
+};
+
+const getEmojiFromWeb = src => {
+  return `<img src="${src}" height="18px" width="18px" alt="faqButtonEmoji" />`;
 };
 
 export const EMOJI = {
-  emoji_1f519: getEmoji('back-with-leftwards-arrow-above_1f519.png'),
-  emoji_1f4da: getEmoji('books_1f4da.png'),
-  emoji_1f4c8: getEmoji('chart-with-upwards-trend_1f4c8.png'),
-  emoji_1f393: getEmoji('graduation-cap_1f393.png'),
-  emoji_1f4dd: getEmoji('memo_1f4dd.png'),
-  emoji_1f478: getEmoji('princess_1f478.png'),
-  emoji_1f4e2: getEmoji('public-address-loudspeaker_1f4e2.png'),
-  emoji_1f3eb: getEmoji('school_1f3eb.png'),
-  emoji_1f5d3: getEmoji('spiral-calendar-pad_1f5d3.png'),
-  emoji_1f4c6: getEmoji('tear-off-calendar_1f4c6.png'),
-  emoji_1f381: getEmoji('wrapped-present_1f381.png'),
+  emoji_1f519: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/back-with-leftwards-arrow-above_1f519.png'
+  ),
+  emoji_1f4da: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/books_1f4da.png'
+  ),
+  emoji_1f4c8: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/chart-with-upwards-trend_1f4c8.png'
+  ),
+  emoji_1f393: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/graduation-cap_1f393.png'
+  ),
+  emoji_1f4dd: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/memo_1f4dd.png'
+  ),
+  emoji_1f478: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/princess_1f478.png'
+  ),
+  emoji_1f4e2: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/public-address-loudspeaker_1f4e2.png'
+  ),
+  emoji_1f3eb: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/school_1f3eb.png'
+  ),
+  emoji_1f5d3: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/spiral-calendar-pad_1f5d3.png'
+  ),
+  emoji_1f4c6: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/tear-off-calendar_1f4c6.png'
+  ),
+  emoji_1f381: getEmojiFromWeb(
+    'https://em-content.zobj.net/thumbs/160/apple/118/wrapped-present_1f381.png'
+  ),
 };

--- a/pages/main/index.js
+++ b/pages/main/index.js
@@ -1,5 +1,7 @@
-const LOGO_TRANSPARENT = '/public/images/headerLogo.png';
-const LOGO_WHITE = '/public/images/headerLogoWhite.png';
+const LOGO_TRANSPARENT =
+  'https://user-images.githubusercontent.com/88099590/243233646-7ed71c7e-7040-4ea1-a213-70b1442cc270.png';
+const LOGO_WHITE =
+  'https://user-images.githubusercontent.com/88099590/243233655-037fb19f-d8b6-421a-81e8-81dc841419f5.png';
 const MENU_TRANSPARENT = '/public/images/header.svg';
 const MENU_WHITE = '/public/images/headerWhite.svg';
 


### PR DESCRIPTION
### 코드 작성 이유
배포환경에서 이미지 다운 속도가 너무 느려 UX가 좋지 않음
<br>

### 상세 사항
- 로고 : CDN에 직접 올리고 싶지만 우선 깃헙 CDN 활용
- 이모지 : 이모지 사이트 이용
<br>

### 참고 사항
- 추후 CDN 활용 필요
<br>

#### CheckList

- [x] 웹표준 준수
- [x] 코딩 컨벤션 준수
- [x] 커밋 컨벤션 준수
